### PR TITLE
Handle deleted files status correctly

### DIFF
--- a/status.go
+++ b/status.go
@@ -122,10 +122,10 @@ func (st *Status) ReadFrom(r io.Reader) (n int64, err error) {
 		switch {
 		case first == '#' && second == '#':
 			err = st.parseHeader(line)
-		case second == 'M':
-			st.NumModified++
 		case first == 'U', second == 'U':
 			st.NumConflicts++
+		case second == 'M', second == 'D':
+			st.NumModified++
 		case first == '?' && second == '?':
 			st.NumUntracked++
 		default:

--- a/status_test.go
+++ b/status_test.go
@@ -121,10 +121,11 @@ func TestStatusParseModified(t *testing.T) {
 				"AM added to index",
 				"RM renamed in index",
 				"CM copied in index",
+				" D deleted in index",
 			),
 			want: Status{
 				LocalBranch: "master",
-				NumModified: 5,
+				NumModified: 6,
 			},
 		},
 	}
@@ -242,11 +243,12 @@ func TestStatusParseStaged(t *testing.T) {
 				`A  "dir1/dir2/nested with carrier \nreturn"`,
 				`M  fileb`,
 				`A  newfile`,
+				`D  deleted`,
 				`?? untracked`,
 			),
 			want: Status{
 				IsDetached:   true,
-				NumStaged:    6,
+				NumStaged:    7,
 				NumUntracked: 1,
 			},
 		},


### PR DESCRIPTION
when i have deleted files like below:

```
:) % git status --porcelain
 D status.go
D  status_test.go
```

in this case, `status.go` is not staged and `status_test.go` is staged.
but `gitstatus` output counts `Staged` both

```
:) % gitstatus
{
 "NumModified": 0,
 "NumConflicts": 0,
 "NumUntracked": 0,
 "NumStaged": 2,
 "NumStashed": 0,
 "HEAD": "aa630bb",
 "LocalBranch": "izumin5210/del",
 "RemoteBranch": "",
 "AheadCount": 0,
 "BehindCount": 0,
 "State": "default",
 "IsInitial": false,
 "IsDetached": false,
 "IsClean": false
}
```