### PR TITLE
Add GIT_OPTIONAL_LOCKS=0 for all git calls

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -18,7 +18,10 @@ type parserFrom interface {
 func runAndParse(p parserFrom, prog string, args ...string) error {
 	if env == nil {
 		// cache env
-		env = []string{"LC_ALL=C"}
+		env = []string{
+			"LC_ALL=C",             // override any user-specific localization
+			"GIT_OPTIONAL_LOCKS=0", // disable operations requiring locks
+		}
 
 		home, ok := os.LookupEnv("HOME")
 		if ok {


### PR DESCRIPTION
This tells git to not perform operations that require locking.
After all gitstatus is used to retrieve the git status of a
repository, but this should not interfere with other
user-initiated operations that do require locking. This has the
effect of making git fetch, commit, pull, etc. prioritary with
respect to operations initiated by gitstatus.